### PR TITLE
Fix for Java.Lang.Runtime Exception for Unmarshalled code

### DIFF
--- a/SlidingMenuSharp/SlidingMenu.cs
+++ b/SlidingMenuSharp/SlidingMenu.cs
@@ -472,14 +472,14 @@ namespace SlidingMenuSharp
             set { _viewBehind.CanvasTransformer = value; }
         }
 
-        public class SavedState: BaseSavedState
+        public class SavedState : BaseSavedState
         {
             public int Item { get; private set; }
 
-            public SavedState(IParcelable superState, int item)
+            public SavedState(IParcelable superState)
                 : base(superState)
             {
-                Item = item;
+
             }
 
             public SavedState(Parcel parcel)
@@ -518,9 +518,14 @@ namespace SlidingMenuSharp
         {
             try
             {
-                var savedState = (SavedState)state;
-                base.OnRestoreInstanceState(savedState.SuperState);
-                _viewAbove.SetCurrentItem(savedState.Item);
+                Bundle bundle = state as Bundle;
+                if (bundle != null)
+                {
+                    IParcelable superState = (IParcelable)bundle.GetParcelable("base");
+                    if (superState != null)
+                        base.OnRestoreInstanceState(superState);
+                    _viewAbove.SetCurrentItem(bundle.GetInt("currentPosition", 0));
+                }
             }
             catch
             {
@@ -532,8 +537,11 @@ namespace SlidingMenuSharp
         protected override IParcelable OnSaveInstanceState()
         {
             var superState = base.OnSaveInstanceState();
-            var savedState = new SavedState(superState, _viewAbove.GetCurrentItem());
-            return savedState;
+            Bundle state = new Bundle();
+            state.PutParcelable("base", superState);
+            state.PutInt("currentPosition", _viewAbove.GetCurrentItem());
+
+            return state;
         }
 
         protected override bool FitSystemWindows(Rect insets)


### PR DESCRIPTION
Fix for OnRestoreInstanceState Crash : 

E/AndroidRuntime(4835): FATAL EXCEPTION: main
11-12 22:36:31.410: E/AndroidRuntime(4835): java.lang.RuntimeException: Unable to start activity ComponentInfo{com.example./com.example.HomeActivity}: java.lang.RuntimeException: Parcel android.os.Parcel@42ab6ad8: Unmarshalling unknown type code 7209057 at offset 1064

Changes made to SavedState class, OnRestoreInstanceState and OnSavedInstanceState
